### PR TITLE
Remove shortcuts that make no sense for Qubes Dom0

### DIFF
--- a/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
+++ b/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-keyboard-shortcuts" version="1.0">
+  <property name="commands" type="empty">
+    <property name="default" type="empty">
+      <property name="&lt;Alt&gt;F1" type="string" value="xfce4-popup-applicationsmenu"/>
+      <property name="&lt;Alt&gt;F2" type="string" value="xfce4-appfinder --collapsed">
+        <property name="startup-notify" type="bool" value="true"/>
+      </property>
+      <property name="&lt;Alt&gt;F3" type="string" value="xfce4-appfinder">
+        <property name="startup-notify" type="bool" value="true"/>
+      </property>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Delete" type="string" value="xflock4"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;Escape" type="string" value="xkill"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;l" type="string" value="xflock4"/>
+      <property name="XF86Display" type="string" value="xfce4-display-settings --minimal"/>
+      <property name="&lt;Super&gt;p" type="string" value="xfce4-display-settings --minimal"/>
+      <property name="&lt;Primary&gt;Escape" type="string" value="xfdesktop --menu"/>
+      <property name="XF86LogOff" type="string" value="xfce4-session-logout"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;L" type="string" value="xfce4-session-logout"/>
+      <property name="Print" type="string" value="xfce4-screenshooter -f"/>
+      <property name="&lt;Alt&gt;Print" type="string" value="xfce4-screenshooter -w"/>
+      <property name="XF86WWW" type="string" value="exo-open --launch WebBrowser"/>
+      <property name="XF86Mail" type="string" value="exo-open --launch MailReader"/>
+      <property name="XF86Calendar" type="string" value="orage"/>
+      <property name="XF86Memo" type="string" value="xfce4-notes"/>
+      <property name="XF86Terminal" type="string" value="xfce4-terminal"/>
+      <property name="XF86Explorer" type="string" value="Thunar"/>
+      <property name="XF86AudioMedia" type="string" value="pragha"/>
+      <property name="XF86AudioPlay" type="string" value="pragha --pause"/>
+      <property name="XF86AudioPrev" type="string" value="pragha --prev"/>
+      <property name="XF86AudioNext" type="string" value="pragha --next"/>
+      <property name="XF86Calculator" type="string" value="galculator"/>
+    </property>
+  </property>
+  <property name="xfwm4" type="empty">
+    <property name="default" type="empty">
+      <property name="&lt;Alt&gt;Insert" type="string" value="add_workspace_key"/>
+      <property name="Escape" type="string" value="cancel_key"/>
+      <property name="Left" type="string" value="left_key"/>
+      <property name="Right" type="string" value="right_key"/>
+      <property name="Up" type="string" value="up_key"/>
+      <property name="Down" type="string" value="down_key"/>
+      <property name="&lt;Alt&gt;Tab" type="string" value="cycle_windows_key"/>
+      <property name="&lt;Alt&gt;&lt;Shift&gt;Tab" type="string" value="cycle_reverse_windows_key"/>
+      <property name="&lt;Alt&gt;Delete" type="string" value="del_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Down" type="string" value="down_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Left" type="string" value="left_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Down" type="string" value="lower_window_key"/>
+      <property name="&lt;Alt&gt;F4" type="string" value="close_window_key"/>
+      <property name="&lt;Alt&gt;F6" type="string" value="stick_window_key"/>
+      <property name="&lt;Alt&gt;F7" type="string" value="move_window_key"/>
+      <property name="&lt;Alt&gt;F8" type="string" value="resize_window_key"/>
+      <property name="&lt;Alt&gt;F9" type="string" value="hide_window_key"/>
+      <property name="&lt;Alt&gt;F10" type="string" value="maximize_window_key"/>
+      <property name="&lt;Alt&gt;F11" type="string" value="fullscreen_key"/>
+      <property name="&lt;Alt&gt;F12" type="string" value="above_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Left" type="string" value="move_window_left_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;End" type="string" value="move_window_next_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Home" type="string" value="move_window_prev_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Right" type="string" value="move_window_right_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Up" type="string" value="move_window_up_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_1" type="string" value="move_window_workspace_1_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_2" type="string" value="move_window_workspace_2_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_3" type="string" value="move_window_workspace_3_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_4" type="string" value="move_window_workspace_4_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_5" type="string" value="move_window_workspace_5_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_6" type="string" value="move_window_workspace_6_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_7" type="string" value="move_window_workspace_7_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_8" type="string" value="move_window_workspace_8_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_9" type="string" value="move_window_workspace_9_key"/>
+      <property name="&lt;Alt&gt;space" type="string" value="popup_menu_key"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Up" type="string" value="raise_window_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Right" type="string" value="right_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;d" type="string" value="show_desktop_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Up" type="string" value="up_workspace_key"/>
+      <property name="&lt;Super&gt;Tab" type="string" value="switch_window_key"/>
+      <property name="&lt;Primary&gt;F1" type="string" value="workspace_1_key"/>
+      <property name="&lt;Primary&gt;F2" type="string" value="workspace_2_key"/>
+      <property name="&lt;Primary&gt;F3" type="string" value="workspace_3_key"/>
+      <property name="&lt;Primary&gt;F4" type="string" value="workspace_4_key"/>
+      <property name="&lt;Primary&gt;F5" type="string" value="workspace_5_key"/>
+      <property name="&lt;Primary&gt;F6" type="string" value="workspace_6_key"/>
+      <property name="&lt;Primary&gt;F7" type="string" value="workspace_7_key"/>
+      <property name="&lt;Primary&gt;F8" type="string" value="workspace_8_key"/>
+      <property name="&lt;Primary&gt;F9" type="string" value="workspace_9_key"/>
+      <property name="&lt;Primary&gt;F10" type="string" value="workspace_10_key"/>
+      <property name="&lt;Primary&gt;F11" type="string" value="workspace_11_key"/>
+      <property name="&lt;Primary&gt;F12" type="string" value="workspace_12_key"/>
+    </property>
+  </property>
+</channel>

--- a/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
+++ b/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
@@ -20,17 +20,8 @@
       <property name="&lt;Control&gt;&lt;Alt&gt;L" type="string" value="xfce4-session-logout"/>
       <property name="Print" type="string" value="xfce4-screenshooter -f"/>
       <property name="&lt;Alt&gt;Print" type="string" value="xfce4-screenshooter -w"/>
-      <property name="XF86WWW" type="string" value="exo-open --launch WebBrowser"/>
-      <property name="XF86Mail" type="string" value="exo-open --launch MailReader"/>
-      <property name="XF86Calendar" type="string" value="orage"/>
-      <property name="XF86Memo" type="string" value="xfce4-notes"/>
       <property name="XF86Terminal" type="string" value="xfce4-terminal"/>
       <property name="XF86Explorer" type="string" value="Thunar"/>
-      <property name="XF86AudioMedia" type="string" value="pragha"/>
-      <property name="XF86AudioPlay" type="string" value="pragha --pause"/>
-      <property name="XF86AudioPrev" type="string" value="pragha --prev"/>
-      <property name="XF86AudioNext" type="string" value="pragha --next"/>
-      <property name="XF86Calculator" type="string" value="galculator"/>
     </property>
   </property>
   <property name="xfwm4" type="empty">

--- a/xfce4-settings-qubes/xfce4-settings-qubes.spec
+++ b/xfce4-settings-qubes/xfce4-settings-qubes.spec
@@ -16,7 +16,8 @@ Source3:	xfwm4.xml
 Source4:	xfce4-desktop.xml
 Source5:	xfce4-session.xml
 Source6:	xfce4-power-manager.xml
-Source7:	xfce4-xss-lock.desktop
+Source7:	xfce4-keyboard-shortcuts.xml
+Source8:	xfce4-xss-lock.desktop
 
 Requires:	qubes-artwork
 Requires:	xfce4-panel
@@ -38,7 +39,8 @@ install -m 644 -D %{SOURCE3} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-pe
 install -m 644 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
 install -m 644 -D %{SOURCE5} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml.qubes
 install -m 644 -D %{SOURCE6} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes
-install -m 644 -D %{SOURCE7} %{buildroot}%{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
+install -m 644 -D %{SOURCE7} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes
+install -m 644 -D %{SOURCE8} %{buildroot}%{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
 
 %define settings_replace() \
 origfile="`echo %{1} | sed 's/\.qubes$//'`"\
@@ -60,6 +62,9 @@ cp -f "%{1}" "$origfile"\
 
 %triggerin -- xfce4-power-manager
 %settings_replace %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes
+
+%triggerin -- libxfce4ui
+%settings_replace %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes
 
 %triggerin -- xscreensaver-base
 
@@ -83,6 +88,7 @@ REPLACEFILE="${REPLACEFILE} %{_sysconfdir}/xdg/xfce4/panel/default.xml.qubes"
 REPLACEFILE="${REPLACEFILE} %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml.qubes"
 REPLACEFILE="${REPLACEFILE} %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml.qubes"
 REPLACEFILE="${REPLACEFILE} %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes"
+REPLACEFILE="${REPLACEFILE} %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes"
 if [ $1 -lt 1 ]; then
 	for file in ${REPLACEFILE}; do
 		origfile="`echo $file | sed 's/\.qubes$//'`"
@@ -98,6 +104,7 @@ fi
 %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
 %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml.qubes
 %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes
+%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes
 %{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
 
 %changelog


### PR DESCRIPTION
The programs launched by these are not (nor should they be) installed by default, as running them in Dom0 would be against Qubes principles.

This also paves the way for adding qubes-specific shortcuts, as desired for https://github.com/QubesOS/qubes-issues/issues/881