### PR TITLE
Mitigate GUI DoS (part 1)

### DIFF
--- a/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
+++ b/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
@@ -22,6 +22,8 @@
       <property name="&lt;Alt&gt;Print" type="string" value="xfce4-screenshooter -w"/>
       <property name="XF86Terminal" type="string" value="xfce4-terminal"/>
       <property name="XF86Explorer" type="string" value="Thunar"/>
+      <property name="&lt;Control&gt;&lt;Shift&gt;P" type="string" value="qvm-run --pause --all"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;&lt;Shift&gt;P" type="string" value="qvm-run --unpause --all"/>
     </property>
   </property>
   <property name="xfwm4" type="empty">


### PR DESCRIPTION
A rogue VM can be very annoying and prevent you from using your
computer by creating tons of giant windows above everything else.

Trying to use qubes-manager to pause the rogue VM would be nearly
impossible, because the rogue VM could prevent you from seeing and
interacting with the qubes-manager window.

Having a keyboard shortcut to pause all VMs allows you to guarantee
that you can bring qubes-manager to the front to kill the offending VM.

Thanks to rustybird:
https://github.com/QubesOS/qubes-issues/issues/881#issuecomment-259900889

Partially fixes https://github.com/QubesOS/qubes-issues/issues/881
Still needs potentially a better window-killing mechanism, and docs.