### PR TITLE
Revert "Mitigate GUI DoS (part 1)"

### DIFF
--- a/xfce4-settings-qubes/qubes-update-xfce-config.desktop
+++ b/xfce4-settings-qubes/qubes-update-xfce-config.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Update Qubes specific xfce config
+Exec=/usr/lib/qubes/update-xfce-config
+Terminal=false
+Type=Application
+OnlyShowIn=XFCE;
+StartupNotify=false

--- a/xfce4-settings-qubes/update-xfce-config
+++ b/xfce4-settings-qubes/update-xfce-config
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+UPDATE_CONFIG_DONE_FILE="$HOME/.config/qubes-xfce-config-update"
+UPDATE_CONFIG_DONE=$(cat "$UPDATE_CONFIG_DONE_FILE" 2>/dev/null || echo 0)
+
+# reset xfconf property if it has given default value
+reset_xfconf_if_default() {
+    local channel="$1"
+    local prop="$2"
+    local default="$3"
+    local current
+
+    current=$(xfconf-query -c "$channel" -p "$prop") || return 0
+    if [ "$current" = "$default" ]; then
+        xfconf-query -c "$channel" -p "$prop" -r
+    fi
+}
+
+if [ "$UPDATE_CONFIG_DONE" -lt 1 ]; then
+    reset_xfconf_if_default \
+        "xfce4-keyboard-shortcuts" \
+        "/commands/custom/<Control><Shift>P" \
+        "qvm-pause --all"
+    reset_xfconf_if_default \
+        "xfce4-keyboard-shortcuts" \
+        "/commands/custom/<Control><Alt><Shift>P" \
+        "qvm-unpause --all"
+fi
+
+UPDATE_CONFIG_DONE=1
+echo "$UPDATE_CONFIG_DONE" > "$UPDATE_CONFIG_DONE_FILE" 

--- a/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
+++ b/xfce4-settings-qubes/xfce4-keyboard-shortcuts.xml
@@ -21,8 +21,6 @@
       <property name="Print" type="string" value="xfce4-screenshooter -f"/>
       <property name="&lt;Alt&gt;Print" type="string" value="xfce4-screenshooter -w"/>
       <property name="XF86Terminal" type="string" value="xfce4-terminal"/>
-      <property name="&lt;Control&gt;&lt;Shift&gt;P" type="string" value="qvm-pause --all"/>
-      <property name="&lt;Control&gt;&lt;Alt&gt;&lt;Shift&gt;P" type="string" value="qvm-unpause --all"/>
     </property>
   </property>
   <property name="xfwm4" type="empty">

--- a/xfce4-settings-qubes/xfce4-settings-qubes.spec
+++ b/xfce4-settings-qubes/xfce4-settings-qubes.spec
@@ -18,6 +18,8 @@ Source5:	xfce4-session.xml
 Source6:	xfce4-power-manager.xml
 Source7:	xfce4-keyboard-shortcuts.xml
 Source8:	xfce4-xss-lock.desktop
+Source9:	qubes-update-xfce-config.desktop
+Source10:	update-xfce-config
 
 Requires:	qubes-artwork
 Requires:	xfce4-panel
@@ -40,8 +42,10 @@ install -m 644 -D %{SOURCE4} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-pe
 install -m 644 -D %{SOURCE5} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml.qubes
 install -m 644 -D %{SOURCE6} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes
 install -m 644 -D %{SOURCE7} %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes
-install -m 644 -D %{SOURCE8} %{buildroot}%{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
 ln -s ../../panel/default.xml %{buildroot}%{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+install -m 644 -D %{SOURCE8} %{buildroot}%{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
+install -m 644 -D %{SOURCE9} %{buildroot}%{_sysconfdir}/xdg/autostart/qubes-update-xfce-config.desktop
+install -m 755 -D %{SOURCE10} %{buildroot}/usr/lib/qubes/update-xfce-config
 
 %define settings_replace() \
 qubesfile="%{1}" \
@@ -109,6 +113,8 @@ fi
 %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml.qubes
 %{_sysconfdir}/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml.qubes
 %{_sysconfdir}/xdg/autostart/xfce4-xss-lock.desktop
+%{_sysconfdir}/xdg/autostart/qubes-update-xfce-config.desktop
+/usr/lib/qubes/update-xfce-config
 
 %changelog
 


### PR DESCRIPTION
First of all Ctrl+Alt+P is too common key combo (for example conflicts
with Firefox's "New Private Window"). But even if that wouldn't be true,
in the current shape it does more harm than good, because it is
not documented (hard to discover when actually needed), and also
pause system VMs which in case of sys-usb and USB keyboard is
fatal.

Lets rethink this first.

This reverts commit 9459331a3772decbaa3948cf6f45d98fd87ec800.
And adds a script to adjust user configuration.
QubesOS/qubes-issues#881
QubesOS/qubes-issues#4101
Fixes QubesOS/qubes-issues#4700