### PR TITLE
Use default title color, except for black

### DIFF
--- a/xfwm4/title-colors.patch
+++ b/xfwm4/title-colors.patch
@@ -69,7 +69,7 @@ index 1b3c85fe2..662553d4b 100644
      xfwmColorSymbol colsym[ XPM_COLOR_SYMBOL_SIZE + 1 ];
      /* hash table label_color->Decoration* */
 diff --git a/src/settings.c b/src/settings.c
-index f0e2dd899..45e0fd413 100644
+index f0e2dd899..de21a7ac0 100644
 --- a/src/settings.c
 +++ b/src/settings.c
 @@ -291,6 +291,34 @@ setXfwmColor (ScreenInfo *screen_info, XfwmColor *color, Settings *rc, int id, c
@@ -139,8 +139,8 @@ index f0e2dd899..45e0fd413 100644
 +    setXfwmColor (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_ORIGINAL][ACTIVE], rc, 0, "fg", "selected");
 +    setXfwmColor (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_ORIGINAL][INACTIVE], rc, 1, "fg", "insensitive");
 +
-+    setXfwmColorSimple (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_DARK][ACTIVE], &qubes_title_colors_dark[ACTIVE]);
-+    setXfwmColorSimple (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_DARK][INACTIVE], &qubes_title_colors_dark[INACTIVE]);
++    setXfwmColor (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_DARK][ACTIVE], rc, 0, "fg", "selected");
++    setXfwmColor (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_DARK][INACTIVE], rc, 1, "fg", "insensitive");
 +
 +    setXfwmColorSimple (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_LIGHT][ACTIVE], &qubes_title_colors_light[ACTIVE]);
 +    setXfwmColorSimple (screen_info, &screen_info->qubes_title_colors[QUBES_TITLE_LIGHT][INACTIVE], &qubes_title_colors_light[INACTIVE]);
@@ -149,7 +149,7 @@ index f0e2dd899..45e0fd413 100644
      setXfwmColor (screen_info, &screen_info->title_shadow_colors[INACTIVE], rc, 3, "dark", "insensitive");
  
 diff --git a/src/settings.h b/src/settings.h
-index f74889abd..049607004 100644
+index f74889abd..374071e89 100644
 --- a/src/settings.h
 +++ b/src/settings.h
 @@ -169,6 +169,14 @@ enum
@@ -167,17 +167,12 @@ index f74889abd..049607004 100644
  /* RGB values */
  static const guint qubes_label_colors[] = {
      0xFFFFFFFF, /* QUBES_LABEL_DOM0 */
-@@ -189,6 +197,19 @@ struct _XfwmColor
+@@ -189,6 +197,14 @@ struct _XfwmColor
      gboolean allocated;
  };
  
 +/* Title colors: active, inactive */
 +/* (GdkColor is: 32-bit pixel (unused here), 16-bit red, green, blue) */
-+
-+static const GdkColor qubes_title_colors_dark[2] = {
-+    { 0, 0, 0, 0 },
-+    { 0, 0x5555, 0x5555, 0x5555 },
-+};
 +
 +static const GdkColor qubes_title_colors_light[2] = {
 +    { 0, 0xCCCC, 0xCCCC, 0xCCCC },


### PR DESCRIPTION
This is a partial revert of the change introduced in
d2e53b3d143d6fc7017fb946bfe84a6330246ec7.

The title colors look improve the text visibility for the default
theme (particularly inactive text); however, they make the sitation
worse if you want to use a different theme.

For now, override the title only in the black-on-black case to fix
the usability regression. In 4.1, I'll be trying to do something
more helpful to the user.

See discussion in QubesOS/qubes-issues#5800.