### PR TITLE
Replace “xkill” with “qvm-xkill”

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: http://www.qubes-os.org
 Package: xfce4-settings-qubes
 Section: xfce
 Architecture: amd64
-Depends: qubes-artwork, xfce4-panel, xss-lock, ${shlibs:Depends}, ${misc:Depends}
+Depends: qubes-artwork, xfce4-panel, xss-lock, ${shlibs:Depends}, ${misc:Depends}, util-linux
 Provides: ${diverted-files}
 Conflicts: ${diverted-files}
 Description: Default Xfce4 panel settings for Qubes.

--- a/update-xfce-config
+++ b/update-xfce-config
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-set -e
+set -eu
 
 UPDATE_CONFIG_DONE_FILE="$HOME/.config/qubes-xfce-config-update"
+UPDATE_CONFIG_LOCK_FILE="$UPDATE_CONFIG_DONE_FILE.lock"
+exec 3>>"$UPDATE_CONFIG_LOCK_FILE"
+flock 3
+{
 UPDATE_CONFIG_DONE=$(cat "$UPDATE_CONFIG_DONE_FILE" 2>/dev/null || echo 0)
 
 # reset xfconf property if it has given default value
@@ -14,7 +18,11 @@ reset_xfconf_if_default() {
 
     current=$(xfconf-query -c "$channel" -p "$prop") || return 0
     if [ "$current" = "$default" ]; then
-        xfconf-query -c "$channel" -p "$prop" -r
+        if [ "$#" -gt 3 ]; then
+            xfconf-query -c "$channel" -p "$prop" -s "$4"
+        else
+            xfconf-query -c "$channel" -p "$prop" -r
+        fi
     fi
 }
 
@@ -28,6 +36,16 @@ if [ "$UPDATE_CONFIG_DONE" -lt 1 ]; then
         "/commands/custom/<Control><Alt><Shift>P" \
         "qvm-unpause --all"
 fi
+if [ "$UPDATE_CONFIG_DONE" -lt 2 ]; then
+    reset_xfconf_if_default \
+        "xfce4-keyboard-shortcuts" \
+        "/commands/custom/<Control><Alt>Escape" \
+        "xkill" \
+        "qvm-xkill"
+fi
 
-UPDATE_CONFIG_DONE=1
+
+UPDATE_CONFIG_DONE=2
 echo "$UPDATE_CONFIG_DONE" > "$UPDATE_CONFIG_DONE_FILE" 
+} 3>&-
+# vim: set ft=sh ff=unix fenc=UTF-8 eol sw=4 ts=4 sts=4 et:

--- a/update-xfce-config
+++ b/update-xfce-config
@@ -10,7 +10,7 @@ flock 3
 UPDATE_CONFIG_DONE=$(cat "$UPDATE_CONFIG_DONE_FILE" 2>/dev/null || echo 0)
 
 # reset xfconf property if it has given default value
-reset_xfconf_if_default() {
+reset_xfconf_if_default () {
     local channel="$1"
     local prop="$2"
     local default="$3"
@@ -26,24 +26,20 @@ reset_xfconf_if_default() {
     fi
 }
 
+reset_xfcommand_if_default ()  {
+    local i
+    for i in custom default; do
+        reset_xfconf_if_default xfce4-keyboard-shortcuts "/commands/$i/$@"
+    done
+}
+
 if [ "$UPDATE_CONFIG_DONE" -lt 1 ]; then
-    reset_xfconf_if_default \
-        "xfce4-keyboard-shortcuts" \
-        "/commands/custom/<Control><Shift>P" \
-        "qvm-pause --all"
-    reset_xfconf_if_default \
-        "xfce4-keyboard-shortcuts" \
-        "/commands/custom/<Control><Alt><Shift>P" \
-        "qvm-unpause --all"
+    reset_xfcommand_if_default "<Control><Shift>P" "qvm-pause --all"
+    reset_xfcommand_if_default "<Control><Alt><Shift>P" "qvm-unpause --all"
 fi
 if [ "$UPDATE_CONFIG_DONE" -lt 2 ]; then
-    reset_xfconf_if_default \
-        "xfce4-keyboard-shortcuts" \
-        "/commands/custom/<Control><Alt>Escape" \
-        "xkill" \
-        "qvm-xkill"
+    reset_xfcommand_if_default "<Control><Alt>Escape" "xkill" "qvm-xkill"
 fi
-
 
 UPDATE_CONFIG_DONE=2
 echo "$UPDATE_CONFIG_DONE" > "$UPDATE_CONFIG_DONE_FILE" 

--- a/xfce4-keyboard-shortcuts.xml
+++ b/xfce4-keyboard-shortcuts.xml
@@ -11,7 +11,7 @@
         <property name="startup-notify" type="bool" value="true"/>
       </property>
       <property name="&lt;Primary&gt;&lt;Alt&gt;Delete" type="string" value="xflock4"/>
-      <property name="&lt;Control&gt;&lt;Alt&gt;Escape" type="string" value="xkill"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;Escape" type="string" value="qvm-xkill"/>
       <property name="&lt;Primary&gt;&lt;Alt&gt;l" type="string" value="xflock4"/>
       <property name="XF86Display" type="string" value="xfce4-display-settings --minimal"/>
       <property name="&lt;Super&gt;p" type="string" value="xfce4-display-settings --minimal"/>

--- a/xfce4-settings-qubes.spec.in
+++ b/xfce4-settings-qubes.spec.in
@@ -11,6 +11,7 @@ Source0:	%{name}-%{version}.tar.gz
 Requires:	qubes-artwork
 Requires:	xfce4-panel
 Requires:	xss-lock
+Requires:	util-linux
 Requires(post):	xfce4-panel
 
 # We ship garcon menu file into this package


### PR DESCRIPTION
`qvm-xkill` can handle override redirect windows, which `xkill` cannot.

Fixes https://github.com/QubesOS/qubes-issues/issues/6235