### PR TITLE
Fix power manager plugin icon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,4 @@
 include:
-- file: /r4.1/gitlab-base.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-dom0.yml
-  project: QubesOS/qubes-continuous-integration
-- file: /r4.1/gitlab-vm.yml
-  project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
 - file: /r4.2/gitlab-host.yml

--- a/xfce4-panel-qubes-default.xml
+++ b/xfce4-panel-qubes-default.xml
@@ -16,6 +16,7 @@
         <value type="int" value="4"/>
         <value type="int" value="5"/>
         <value type="int" value="7"/>
+        <value type="int" value="8"/>
         <value type="int" value="6"/>
         <value type="int" value="2"/>
       </property>
@@ -37,5 +38,6 @@
     <property name="plugin-5" type="string" value="clock"/>
     <property name="plugin-7" type="string" value="pulseaudio"/>
     <property name="plugin-6" type="string" value="systray"/>
+    <property name="plugin-8" type="string" value="power-manager-plugin"/>
   </property>
 </channel>


### PR DESCRIPTION
Power manager icon icon for no batter is broken when using legacy
notification icon. Use proper xfce plugin instead.
See https://gitlab.xfce.org/xfce/xfce4-power-manager/-/issues/104 for
details.

Related to QubesOS/qubes-issues#7453