### PR TITLE
Change default value of panel output-name to 'Primary' in order to have xfce taskbar (panel) shown on primary display by default

### DIFF
--- a/xfce4-panel-qubes-default.xml
+++ b/xfce4-panel-qubes-default.xml
@@ -7,6 +7,7 @@
     <property name="panel-1" type="empty">
       <property name="position" type="string" value="p=6;x=0;y=0"/>
       <property name="length" type="uint" value="100"/>
+      <property name="output-name" type="string" value="Primary"/>
       <property name="position-locked" type="bool" value="true"/>
       <property name="size" type="uint" value="30"/>
       <property name="plugin-ids" type="array">


### PR DESCRIPTION
Pull request as described in the title.

I also opened a ticket on qubes-issues to have a central tracking of this feature request and give the opportunity to the community to react to the proposal.