### PR TITLE
Disable forced DPI to fix font kerning

### DIFF
--- a/xsettings.xml
+++ b/xsettings.xml
@@ -18,7 +18,7 @@
     <property name="EnableInputFeedbackSounds" type="bool" value="false"/>
   </property>
   <property name="Xft" type="empty">
-    <property name="DPI" type="empty"/>
+    <property name="DPI" type="int" value="-1"/>
     <property name="Antialias" type="int" value="1"/>
     <property name="Hinting" type="int" value="-1"/>
     <property name="HintStyle" type="string" value="hintfull"/>


### PR DESCRIPTION
Looks like default forced 96 DPI breaks font kerning on Fedora 44.
Disable it, not just leave empty.

Fixes QubesOS/qubes-issues#10840
