### PR TITLE
Disable automatic session saving on logout

### DIFF
--- a/xfce4-session.xml
+++ b/xfce4-session.xml
@@ -3,6 +3,7 @@
 <channel name="xfce4-session" version="1.0">
   <property name="general" type="empty">
     <property name="FailsafeSessionName" type="string" value="Failsafe"/>
+    <property name="SaveOnExit" type="bool" value="false"/>
   </property>
   <property name="sessions" type="empty">
     <property name="Failsafe" type="empty">


### PR DESCRIPTION
The checkbox in logout dialog is removed in newer xfce, so it's no
longer automatically enabled. But lets having now already. See:
See https://gitlab.xfce.org/xfce/xfce4-session/-/work_items/105#note_86415

QubesOS/qubes-issues#4972
